### PR TITLE
Fixed broken links in table of content. Fixed issue #1036

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
      - [MATLAB/Octave](#121-matlab/octave)
 
 2.  [Hackathons and Events](#2-hackathons-and-events)
-     - [Top Global Hackathons](#21-top-global-hackathons)
-     - [Competitions](#22-competitions)
+     - [Top Global Hackathons](#21-top-global-hackathons-)
+     - [Competitions](#22-competitions-)
      - [Hackathon Search Portal](#23--hackathon-search-portals-dart)
      - [Events](#24-events)
      - [Startup Summits and Competitions](#25-startup-summits-competitions-and-bootcamps-neckbeard)
@@ -537,7 +537,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 
 # 2. Hackathons and Events
 
-## 2.1 Top Global Hackathons :globe_with_meridians:
+## 2.1 Top Global Hackathons 🌐
 
 
 |Id |Name | Place| Travel Reimbursement |Application Start | Application End | Event Date |
@@ -589,7 +589,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 
 ----------------------------------------------------------
 
-##  2.2 Competitions :trophy:
+##  2.2 Competitions 🏆
 
 |ID| Name  | Location |
 |--|------ |----------|

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
      - [Top Global Hackathons](#21-top-global-hackathons-)
      - [Competitions](#22-competitions-)
      - [Hackathon Search Portal](#23--hackathon-search-portals-dart)
-     - [Events](#24-events)
+     - [Events](#24-events-)
      - [Startup Summits and Competitions](#25-startup-summits-competitions-and-bootcamps-neckbeard)
      - [Hiring Challenges](#26-hiring-challenges)
 
@@ -633,7 +633,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 |6| [Analytical Vidya](https://www.analyticsvidhya.com/) | Online & On-Site | Data Science | |
 |7| [Hackathon.com](https://www.hackathon.com/) [Online & On-site] | Global | ALL |
 
-## 2.4 Events :ticket:
+## 2.4 Events 🎫
 
 > **Check out these events for your region**
 


### PR DESCRIPTION
I fixed the links that didn't take user to the respective sections within the Hackathons table of content section by replace the emojis with hard values of the emojis. I copied and pasted the emojis directly into the markdown file and it worked 😄 