### PR TITLE
Added a new course on C++, the one that's up on Udacity

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -372,6 +372,7 @@ Instructions :
 | 338 | **Santiago Correa** | Spain | Software Developer | [GitHub](https://github.com/santiago0697) |
 | 329 | **William Lin** | United States | Software Engineer | [GitHub](https://github.com/FanciestW) |
 | 330 | **Shivam Arora** | India |  Computer Engineer |[Linkedin](https://www.linkedin.com/in/shivam-ar/) - [StackOverflow](https://stackoverflow.com/users/8160087/shivam-arora) |
+| 331 | **Md Rafi Akhtar** | India |  Student |[GitHub](https://github.com/rafi007akhtar)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
  - [C++ Class | Google for Education ](https://developers.google.com/edu/c++/)
  - [Tutorials Point](https://www.tutorialspoint.com/cplusplus/)
  - [GeeksForGeeks](https://www.geeksforgeeks.org/c-plus-plus/)
+ - [C++ For Programmers | Udacity](https://in.udacity.com/course/c-for-programmers--ud210)
 
  ## 1.11 Git and Github
  - [Git Tutorials](https://www.atlassian.com/git/tutorials/comparing-workflows)


### PR DESCRIPTION
The README had a number of cool links on C++ tutorials, but unlike most other language sections, it does not have any full-length course on C++.

**What I did.** Added a link to a relatively new C++ course, namely _C++ For Programmers_, which is available to be taken on Udacity. You can visit the course [here](https://in.udacity.com/course/c-for-programmers--ud210).

**About the course.** Like most other free courses on Udacity, this one is self-paced, has a good theory-to-practise balance, and can be taken by anybody. Perhaps the most convincing argument for the inclusion of this course in the list is that the course has mini-lectures from **Bjarne Stroustrup** spread-out among the lessons!

Hope to see this course added to the resources!

