### PR TITLE
Fixed front-end roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 ## 1.6 Frontend Web Development
 
 - [Frontend Masters](https://frontendmasters.com/) :heavy_dollar_sign:
-- [Frontend Roadmap](https://raw.githubusercontent.com/kamranahmedse/developer-roadmap/master/images/frontend.png)
+- [Frontend Roadmap](https://raw.githubusercontent.com/kamranahmedse/developer-roadmap/faa0ec253021944ef15fe0872673f7e42102d7e9/img/frontend.png)
 - [Frontend Mentor **FREE**](https://www.frontendmentor.io/)
 - [General Assembly Dash **FREE**](https://dash.generalassemb.ly/)
     (General Assembly Dash currently works best in Microsoft Edge as of 10-2018)


### PR DESCRIPTION
As stated in issue number #1350 I have fixed the link for the frontend roadmap and it's working again.

Before - 
<img width="812" alt="Screenshot 2021-03-14 161442" src="https://user-images.githubusercontent.com/68023376/111065835-c99dc480-84e1-11eb-99e3-de097a55b3b4.png">

After - 
<img width="779" alt="Screenshot 2021-03-14 162510" src="https://user-images.githubusercontent.com/68023376/111065847-df12ee80-84e1-11eb-964a-2cda3cfad67d.png">

