### PR TITLE
docs: add Canadian student jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 2. [Internshala](https://internshala.com)
 3. [LinkedIn](https://linkedin.com) *Contact HRs on LinkedIn*
 4. [Indeed](https://www.indeed.ca/)
+5. [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free daily-updated Canadian student internship, co-op, new-grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences.
 
 # Additional Resources
 
@@ -1781,6 +1782,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 2. [Internshala](https://internshala.com)
 3. [LinkedIn](https://linkedin.com) *Contact HRs on LinkedIn*
 4. [Indeed](https://www.indeed.ca/)
+5. [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free daily-updated Canadian student internship, co-op, new-grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the internship portals/resources list
- Position it as a free daily-updated Canadian student job board for internships, co-ops, new-grad, junior, and entry-level roles across multiple fields

## Why
The repo already includes general internship portals such as AngelList, Internshala, LinkedIn, and Indeed. Hanzilla Jobs is a complementary Canada-specific resource for students and recent grads looking for current roles beyond CS-only lists.

## Verification
- Markdown-only change
- `git diff --check` passed
