### PR TITLE
docs: add Hanzilla Jobs internship portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 2. [Internshala](https://internshala.com)
 3. [LinkedIn](https://linkedin.com) *Contact HRs on LinkedIn*
 4. [Indeed](https://www.indeed.ca/)
+5. [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free daily-updated Canadian student internship, co-op, new-grad, junior, and entry-level jobs across tech, engineering, business, finance, sciences, arts, and related fields.
 
 # Additional Resources
 
@@ -1787,6 +1788,7 @@ When I was in college, I missed a lot of opportunities like hackathons, conferen
 2. [Internshala](https://internshala.com)
 3. [LinkedIn](https://linkedin.com) *Contact HRs on LinkedIn*
 4. [Indeed](https://www.indeed.ca/)
+5. [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free daily-updated Canadian student internship, co-op, new-grad, junior, and entry-level jobs across tech, engineering, business, finance, sciences, arts, and related fields.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the internship portals list as a Canada-specific student job-search resource.
- Links directly to the internships/co-op landing page for students looking for Canadian internship, co-op, new-grad, junior, and entry-level roles.

## Why
Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new-grad, junior, and entry-level roles across tech, engineering, business, finance, sciences, arts, and related fields.

## Verification
- README-only change
- `git diff --check` passed
